### PR TITLE
Added check for whether APPLE defined, so we could compile this in xCode too

### DIFF
--- a/include/exceptxx/ErrnoException.h
+++ b/include/exceptxx/ErrnoException.h
@@ -48,7 +48,7 @@ namespace exceptxx
             }
 
             return buffer;
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+#elif ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE) || defined(__APPLE__)
             if (0 != ::strerror_r(m_error, buffer, sizeof(buffer)))
             {
                 return "Unknown error code";


### PR DESCRIPTION
Currently, when we are trying to build this library with ErrnoException usage, we have a compilation error in xCode, saying that it can't convert int to string. 
It's because it uses just return ::strerror_r(...) due to lack of macro defined in macOS. 

The APPLE macro is added here to condition and checked to use appropriate code for macOS.